### PR TITLE
feat: add prioritized free model fallback

### DIFF
--- a/free_model_test.go
+++ b/free_model_test.go
@@ -680,15 +680,15 @@ func TestCallClineAPIFreeDoesNotPickCoolingAccount(t *testing.T) {
 	})
 
 	account := &Account{
-		AccountID:   "glm-cooling",
-		Email:       "cooling@example.com",
-		AccessToken: "token-cooling",
-		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
-		Status:      "active",
-		ModelCooldowns: map[string]time.Time{
-			freeModelPrimary:  time.Now().Add(time.Hour),
-			freeModelFallback: time.Now().Add(time.Hour),
-		},
+		AccountID:      "glm-cooling",
+		Email:          "cooling@example.com",
+		AccessToken:    "token-cooling",
+		ExpiresAt:      time.Now().Add(time.Hour).UnixMilli(),
+		Status:         "active",
+		ModelCooldowns: map[string]time.Time{},
+	}
+	for _, model := range freeModelChain {
+		account.ModelCooldowns[model] = time.Now().Add(time.Hour)
 	}
 	pool = &AccountPool{Accounts: []*Account{account}}
 	setProxyConfig(defaultProxyConfig())
@@ -854,8 +854,8 @@ func TestHandleResponsesFreeReturnsTooManyRequestsWhenBothPoolsUnavailable(t *te
 	if recorder.Code != http.StatusTooManyRequests {
 		t.Fatalf("response status = %d, want %d: %s", recorder.Code, http.StatusTooManyRequests, recorder.Body.String())
 	}
-	if calls != 2 {
-		t.Fatalf("upstream calls = %d, want one attempt per model", calls)
+	if calls != len(freeModelChain) {
+		t.Fatalf("upstream calls = %d, want one attempt per model (%d)", calls, len(freeModelChain))
 	}
 
 	requestLogsMu.Lock()
@@ -863,7 +863,8 @@ func TestHandleResponsesFreeReturnsTooManyRequestsWhenBothPoolsUnavailable(t *te
 	if len(requestLogs) != 1 {
 		t.Fatalf("request log count = %d, want 1", len(requestLogs))
 	}
-	if requestLogs[0].Model != freeModelFallback {
-		t.Fatalf("request log model = %q, want %q", requestLogs[0].Model, freeModelFallback)
+	lastModel := freeModelChain[len(freeModelChain)-1]
+	if requestLogs[0].Model != lastModel {
+		t.Fatalf("request log model = %q, want %q", requestLogs[0].Model, lastModel)
 	}
 }

--- a/free_model_test.go
+++ b/free_model_test.go
@@ -810,7 +810,7 @@ func TestCallClineAPIDirectModelsKeepExactIDWithoutFallback(t *testing.T) {
 	}
 }
 
-func TestHandleResponsesFreeLogsEffectiveModel(t *testing.T) {
+func TestHandleResponsesFreeReturnsTooManyRequestsWhenBothPoolsUnavailable(t *testing.T) {
 	oldPool := pool
 	oldConfig := getProxyConfig()
 	oldTransport := httpClient.Transport
@@ -825,65 +825,6 @@ func TestHandleResponsesFreeLogsEffectiveModel(t *testing.T) {
 		requestLogsMu.Lock()
 		requestLogs = oldLogs
 		requestLogsMu.Unlock()
-	})
-
-	account := &Account{
-		AccountID:   "log-account",
-		Email:       "log@example.com",
-		AccessToken: "log-token",
-		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
-		Status:      "active",
-	}
-	pool = &AccountPool{Accounts: []*Account{account}}
-	setProxyConfig(defaultProxyConfig())
-
-	var upstreamModel string
-	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
-		body, err := io.ReadAll(req.Body)
-		if err != nil {
-			return nil, err
-		}
-		var params map[string]any
-		if err := json.Unmarshal(body, &params); err != nil {
-			return nil, err
-		}
-		upstreamModel, _ = params["model"].(string)
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"id":"ok","model":"z-ai/glm-5.3-flash","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`)),
-			Header:     make(http.Header),
-			Request:    req,
-		}, nil
-	})
-
-	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"free","input":"hello"}`))
-	recorder := httptest.NewRecorder()
-	handleResponses(recorder, req)
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("response status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
-	}
-	if upstreamModel != freeModelPrimary {
-		t.Fatalf("upstream model = %q, want %q", upstreamModel, freeModelPrimary)
-	}
-
-	requestLogsMu.Lock()
-	defer requestLogsMu.Unlock()
-	if len(requestLogs) != 1 {
-		t.Fatalf("request log count = %d, want 1", len(requestLogs))
-	}
-	if requestLogs[0].Model != freeModelPrimary {
-		t.Fatalf("request log model = %q, want %q", requestLogs[0].Model, freeModelPrimary)
-	}
-}
-
-func TestHandleResponsesFreeReturnsTooManyRequestsWhenBothPoolsUnavailable(t *testing.T) {
-	oldPool := pool
-	oldConfig := getProxyConfig()
-	oldTransport := httpClient.Transport
-	t.Cleanup(func() {
-		pool = oldPool
-		setProxyConfig(oldConfig)
-		httpClient.Transport = oldTransport
 	})
 
 	account := &Account{
@@ -915,50 +856,6 @@ func TestHandleResponsesFreeReturnsTooManyRequestsWhenBothPoolsUnavailable(t *te
 	}
 	if calls != 2 {
 		t.Fatalf("upstream calls = %d, want one attempt per model", calls)
-	}
-}
-
-func TestHandleResponsesFreeErrorLogsEffectiveModel(t *testing.T) {
-	oldPool := pool
-	oldConfig := getProxyConfig()
-	oldTransport := httpClient.Transport
-	requestLogsMu.Lock()
-	oldLogs := requestLogs
-	requestLogs = nil
-	requestLogsMu.Unlock()
-	t.Cleanup(func() {
-		pool = oldPool
-		setProxyConfig(oldConfig)
-		httpClient.Transport = oldTransport
-		requestLogsMu.Lock()
-		requestLogs = oldLogs
-		requestLogsMu.Unlock()
-	})
-
-	account := &Account{
-		AccountID:   "error-log-account",
-		Email:       "error-log@example.com",
-		AccessToken: "error-log-token",
-		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
-		Status:      "active",
-	}
-	pool = &AccountPool{Accounts: []*Account{account}}
-	setProxyConfig(defaultProxyConfig())
-
-	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusTooManyRequests,
-			Body:       io.NopCloser(strings.NewReader(`{"error":"quota","message":"Try again in 1h"}`)),
-			Header:     make(http.Header),
-			Request:    req,
-		}, nil
-	})
-
-	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"free","input":"hello"}`))
-	recorder := httptest.NewRecorder()
-	handleResponses(recorder, req)
-	if recorder.Code != http.StatusTooManyRequests {
-		t.Fatalf("response status = %d, want %d: %s", recorder.Code, http.StatusTooManyRequests, recorder.Body.String())
 	}
 
 	requestLogsMu.Lock()

--- a/free_model_test.go
+++ b/free_model_test.go
@@ -1,0 +1,972 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+type freeModelRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f freeModelRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestCallClineAPIRefreshRetryReplaysRequestBody(t *testing.T) {
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	t.Cleanup(func() {
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+	})
+
+	account := &Account{
+		AccountID:    "refresh-account",
+		Email:        "refresh@example.com",
+		RefreshToken: "refresh-token",
+		AccessToken:  "old-access-token",
+		ExpiresAt:    time.Now().Add(time.Hour).UnixMilli(),
+		Status:       "active",
+	}
+	setProxyConfig(defaultProxyConfig())
+
+	var requestBodies []map[string]any
+	refreshCalls := 0
+	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/api/v1/auth/refresh":
+			refreshCalls++
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"data":{"accessToken":"new-access-token","refreshToken":"new-refresh-token","expiresAt":4102444800000}}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		case "/api/v1/chat/completions":
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(body, &payload); err != nil {
+				return nil, err
+			}
+			requestBodies = append(requestBodies, payload)
+			if len(requestBodies) == 1 {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"error":"unauthorized"}`)),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"id":"ok","choices":[]}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		default:
+			return nil, fmt.Errorf("unexpected request path %s", req.URL.Path)
+		}
+	})
+
+	params := map[string]any{
+		"model":    freeModelPrimary,
+		"messages": []any{map[string]any{"role": "user", "content": "hello"}},
+	}
+	resp, _, err := callClineAPIWithAccount(account, params, false)
+	if err != nil {
+		t.Fatalf("callClineAPIWithAccount returned error: %v", err)
+	}
+	resp.Body.Close()
+	if refreshCalls != 1 {
+		t.Fatalf("refresh calls = %d, want 1", refreshCalls)
+	}
+	if len(requestBodies) != 2 {
+		t.Fatalf("Cline request count = %d, want 2", len(requestBodies))
+	}
+	for index, body := range requestBodies {
+		if body["model"] != freeModelPrimary {
+			t.Fatalf("request %d model = %v, want %q", index, body["model"], freeModelPrimary)
+		}
+		messages, ok := body["messages"].([]any)
+		if !ok || len(messages) == 0 {
+			t.Fatalf("request %d messages = %v, want non-empty body", index, body["messages"])
+		}
+	}
+}
+
+func TestCallClineAPIFreeRetriesNextGLMAccountAfterTokenRefreshFailure(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+	})
+
+	first := &Account{
+		AccountID:    "refresh-failed",
+		Email:        "refresh-failed@example.com",
+		RefreshToken: "refresh-one",
+		ExpiresAt:    time.Now().Add(-time.Hour).UnixMilli(),
+		Status:       "active",
+	}
+	second := &Account{
+		AccountID:   "glm-two",
+		Email:       "two@example.com",
+		AccessToken: "token-two",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	pool = &AccountPool{Accounts: []*Account{first, second}}
+	setProxyConfig(defaultProxyConfig())
+
+	var paths []string
+	var attempts []string
+	var models []string
+	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+		paths = append(paths, req.URL.Path)
+		switch req.URL.Path {
+		case "/api/v1/auth/refresh":
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"refresh failed"}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		case "/api/v1/chat/completions":
+			token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
+			attempts = append(attempts, token)
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			var upstream map[string]any
+			if err := json.Unmarshal(body, &upstream); err != nil {
+				return nil, err
+			}
+			model, _ := upstream["model"].(string)
+			models = append(models, model)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"id":"ok","choices":[]}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		default:
+			return nil, fmt.Errorf("unexpected request path %s", req.URL.Path)
+		}
+	})
+
+	params := map[string]any{
+		"model":    "free",
+		"messages": []any{map[string]any{"role": "user", "content": "hello"}},
+	}
+	resp, acc, err := callClineAPI(params, false)
+	if err != nil {
+		t.Fatalf("callClineAPI returned error: %v", err)
+	}
+	resp.Body.Close()
+	if acc != second {
+		t.Fatalf("selected account = %v, want second GLM account", acc)
+	}
+	if got, want := strings.Join(paths, ","), "/api/v1/auth/refresh,/api/v1/chat/completions"; got != want {
+		t.Fatalf("request paths = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(attempts, ","), "token-two"; got != want {
+		t.Fatalf("Cline attempts = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(models, ","), freeModelPrimary; got != want {
+		t.Fatalf("models = %q, want %q", got, want)
+	}
+	if first.Status != "expired" {
+		t.Fatalf("first account status = %q, want expired", first.Status)
+	}
+}
+
+func TestCallClineAPIFreeRetriesNextGLMAccountAfterTransportFailure(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+	})
+
+	first := &Account{
+		AccountID:   "transport-failed",
+		Email:       "transport-failed@example.com",
+		AccessToken: "token-one",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	second := &Account{
+		AccountID:   "glm-two",
+		Email:       "two@example.com",
+		AccessToken: "token-two",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	pool = &AccountPool{Accounts: []*Account{first, second}}
+	setProxyConfig(defaultProxyConfig())
+
+	var attempts []string
+	var models []string
+	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+		token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
+		attempts = append(attempts, token)
+		if token == "token-one" {
+			return nil, fmt.Errorf("connection reset")
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		var upstream map[string]any
+		if err := json.Unmarshal(body, &upstream); err != nil {
+			return nil, err
+		}
+		model, _ := upstream["model"].(string)
+		models = append(models, model)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id":"ok","choices":[]}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	params := map[string]any{
+		"model":    "free",
+		"messages": []any{map[string]any{"role": "user", "content": "hello"}},
+	}
+	resp, acc, err := callClineAPI(params, false)
+	if err != nil {
+		t.Fatalf("callClineAPI returned error: %v", err)
+	}
+	resp.Body.Close()
+	if acc != second {
+		t.Fatalf("selected account = %v, want second GLM account", acc)
+	}
+	if got, want := strings.Join(attempts, ","), "token-one,token-two"; got != want {
+		t.Fatalf("Cline attempts = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(models, ","), freeModelPrimary; got != want {
+		t.Fatalf("models = %q, want %q", got, want)
+	}
+	if first.Status != "cooldown" {
+		t.Fatalf("first account status = %q, want cooldown", first.Status)
+	}
+}
+
+func TestCallClineAPIFreeRetriesNextGLMAccountAfterQuota429(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+	})
+
+	first := &Account{
+		AccountID:   "glm-one",
+		Email:       "one@example.com",
+		AccessToken: "token-one",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	second := &Account{
+		AccountID:   "glm-two",
+		Email:       "two@example.com",
+		AccessToken: "token-two",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	pool = &AccountPool{Accounts: []*Account{first, second}}
+	setProxyConfig(defaultProxyConfig())
+
+	var attempts []string
+	var models []string
+	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+		token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
+		attempts = append(attempts, token)
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		var upstream map[string]any
+		if err := json.Unmarshal(body, &upstream); err != nil {
+			return nil, err
+		}
+		model, _ := upstream["model"].(string)
+		models = append(models, model)
+		if token == "token-one" {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"quota","message":"Try again in 1h"}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id":"ok","choices":[]}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	params := map[string]any{
+		"model":    "free",
+		"messages": []any{map[string]any{"role": "user", "content": "hello"}},
+	}
+	resp, acc, err := callClineAPI(params, false)
+	if err != nil {
+		t.Fatalf("callClineAPI returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("callClineAPI returned nil response")
+	}
+	resp.Body.Close()
+
+	if acc != second {
+		t.Fatalf("selected account = %v, want second GLM account", acc)
+	}
+	if got, want := strings.Join(attempts, ","), "token-one,token-two"; got != want {
+		t.Fatalf("attempts = %q, want %q", got, want)
+	}
+	for index, model := range models {
+		if model != freeModelPrimary {
+			t.Fatalf("attempt %d model = %q, want %q", index, model, freeModelPrimary)
+		}
+	}
+	if got, want := params["model"], freeModelPrimary; got != want {
+		t.Fatalf("effective model = %v, want %q", got, want)
+	}
+}
+
+func TestCallClineAPIFreeFallsBackToDSAfterAllGLMAccountsUnavailable(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+	})
+
+	first := &Account{
+		AccountID:   "glm-one",
+		Email:       "one@example.com",
+		AccessToken: "token-one",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	second := &Account{
+		AccountID:   "glm-two",
+		Email:       "two@example.com",
+		AccessToken: "token-two",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	pool = &AccountPool{Accounts: []*Account{first, second}}
+	setProxyConfig(defaultProxyConfig())
+
+	var attempts []string
+	var models []string
+	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+		token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
+		attempts = append(attempts, token)
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		var upstream map[string]any
+		if err := json.Unmarshal(body, &upstream); err != nil {
+			return nil, err
+		}
+		model, _ := upstream["model"].(string)
+		models = append(models, model)
+		if token == "token-one" && model == "z-ai/glm-5.3-flash" || token == "token-two" {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"quota","message":"Try again in 1h"}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id":"ok","choices":[]}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	params := map[string]any{
+		"model":    "free",
+		"messages": []any{map[string]any{"role": "user", "content": "hello"}},
+	}
+	resp, acc, err := callClineAPI(params, false)
+	if err != nil {
+		t.Fatalf("callClineAPI returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("callClineAPI returned nil response")
+	}
+	resp.Body.Close()
+
+	if acc != first {
+		t.Fatalf("selected account = %v, want first DS account", acc)
+	}
+	if got, want := strings.Join(attempts, ","), "token-one,token-two,token-one"; got != want {
+		t.Fatalf("attempts = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(models, ","), "z-ai/glm-5.3-flash,z-ai/glm-5.3-flash,deepseek/deepseek-v4-flash"; got != want {
+		t.Fatalf("models = %q, want %q", got, want)
+	}
+	if got, want := params["model"], "deepseek/deepseek-v4-flash"; got != want {
+		t.Fatalf("effective model = %v, want %q", got, want)
+	}
+}
+
+func TestCallClineAPIFreeRetriesNextDSAccountAfterQuota429(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+	})
+
+	first := &Account{
+		AccountID:   "ds-one",
+		Email:       "one@example.com",
+		AccessToken: "token-one",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+		ModelCooldowns: map[string]time.Time{
+			freeModelPrimary: time.Now().Add(time.Hour),
+		},
+	}
+	second := &Account{
+		AccountID:   "ds-two",
+		Email:       "two@example.com",
+		AccessToken: "token-two",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+		ModelCooldowns: map[string]time.Time{
+			freeModelPrimary: time.Now().Add(time.Hour),
+		},
+	}
+	pool = &AccountPool{Accounts: []*Account{first, second}}
+	setProxyConfig(defaultProxyConfig())
+
+	var attempts []string
+	var models []string
+	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+		token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
+		attempts = append(attempts, token)
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		var upstream map[string]any
+		if err := json.Unmarshal(body, &upstream); err != nil {
+			return nil, err
+		}
+		model, _ := upstream["model"].(string)
+		models = append(models, model)
+		if token == "token-one" {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"quota","message":"Try again in 1h"}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id":"ok","choices":[]}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	params := map[string]any{
+		"model":    "free",
+		"messages": []any{map[string]any{"role": "user", "content": "hello"}},
+	}
+	resp, acc, err := callClineAPI(params, false)
+	if err != nil {
+		t.Fatalf("callClineAPI returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("callClineAPI returned nil response")
+	}
+	resp.Body.Close()
+
+	if acc != second {
+		t.Fatalf("selected account = %v, want second DS account", acc)
+	}
+	if got, want := strings.Join(attempts, ","), "token-one,token-two"; got != want {
+		t.Fatalf("attempts = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(models, ","), "deepseek/deepseek-v4-flash,deepseek/deepseek-v4-flash"; got != want {
+		t.Fatalf("models = %q, want %q", got, want)
+	}
+	if got, want := params["model"], freeModelFallback; got != want {
+		t.Fatalf("effective model = %v, want %q", got, want)
+	}
+	if !modelCooldownActive(first, freeModelFallback) {
+		t.Fatal("first DS account should retain its DS cooldown")
+	}
+	if !modelCooldownActive(first, freeModelPrimary) {
+		t.Fatal("first DS account should retain its GLM cooldown")
+	}
+}
+
+func TestCallClineAPIFreeReturnsToGLMAfterCooldownExpires(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+	})
+
+	account := &Account{
+		AccountID:   "recovery-account",
+		Email:       "recovery@example.com",
+		AccessToken: "recovery-token",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+		ModelCooldowns: map[string]time.Time{
+			freeModelPrimary: time.Now().Add(time.Hour),
+		},
+	}
+	pool = &AccountPool{Accounts: []*Account{account}}
+	setProxyConfig(defaultProxyConfig())
+
+	var models []string
+	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		var upstream map[string]any
+		if err := json.Unmarshal(body, &upstream); err != nil {
+			return nil, err
+		}
+		model, _ := upstream["model"].(string)
+		models = append(models, model)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id":"ok","choices":[]}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	firstResp, _, err := callClineAPI(map[string]any{"model": "free"}, false)
+	if err != nil {
+		t.Fatalf("first callClineAPI returned error: %v", err)
+	}
+	firstResp.Body.Close()
+	if got, want := models[0], freeModelFallback; got != want {
+		t.Fatalf("first effective model = %q, want %q", got, want)
+	}
+
+	account.ModelCooldowns[freeModelPrimary] = time.Now().Add(-time.Minute)
+	secondResp, _, err := callClineAPI(map[string]any{"model": "free"}, false)
+	if err != nil {
+		t.Fatalf("second callClineAPI returned error: %v", err)
+	}
+	secondResp.Body.Close()
+	if got, want := models[1], freeModelPrimary; got != want {
+		t.Fatalf("second effective model = %q, want %q", got, want)
+	}
+}
+
+func TestCallClineAPIFreeKeepsModelCooldownsIndependent(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+	})
+
+	for _, test := range []struct {
+		name          string
+		cooldownModel string
+		wantModel     string
+	}{
+		{name: "GLM cooldown allows DS", cooldownModel: freeModelPrimary, wantModel: freeModelFallback},
+		{name: "DS cooldown allows GLM", cooldownModel: freeModelFallback, wantModel: freeModelPrimary},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			account := &Account{
+				AccountID:   "independent-account",
+				Email:       "independent@example.com",
+				AccessToken: "independent-token",
+				ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+				Status:      "active",
+				ModelCooldowns: map[string]time.Time{
+					test.cooldownModel: time.Now().Add(time.Hour),
+				},
+			}
+			pool = &AccountPool{Accounts: []*Account{account}}
+			setProxyConfig(defaultProxyConfig())
+
+			var upstreamModel string
+			httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				var upstream map[string]any
+				if err := json.Unmarshal(body, &upstream); err != nil {
+					return nil, err
+				}
+				upstreamModel, _ = upstream["model"].(string)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"id":"ok","choices":[]}`)),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			})
+
+			resp, _, err := callClineAPI(map[string]any{"model": "free"}, false)
+			if err != nil {
+				t.Fatalf("callClineAPI returned error: %v", err)
+			}
+			resp.Body.Close()
+			if upstreamModel != test.wantModel {
+				t.Fatalf("upstream model = %q, want %q", upstreamModel, test.wantModel)
+			}
+			if !modelCooldownActive(account, test.cooldownModel) {
+				t.Fatalf("cooldown for %s was lost", test.cooldownModel)
+			}
+			if modelCooldownActive(account, test.wantModel) {
+				t.Fatalf("cooldown for %s unexpectedly blocked", test.wantModel)
+			}
+		})
+	}
+}
+
+func TestCallClineAPIFreeDoesNotPickCoolingAccount(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+	})
+
+	account := &Account{
+		AccountID:   "glm-cooling",
+		Email:       "cooling@example.com",
+		AccessToken: "token-cooling",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+		ModelCooldowns: map[string]time.Time{
+			freeModelPrimary:  time.Now().Add(time.Hour),
+			freeModelFallback: time.Now().Add(time.Hour),
+		},
+	}
+	pool = &AccountPool{Accounts: []*Account{account}}
+	setProxyConfig(defaultProxyConfig())
+
+	calls := 0
+	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id":"unexpected","choices":[]}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	_, _, err := callClineAPI(map[string]any{"model": "free"}, false)
+	if err == nil {
+		t.Fatal("callClineAPI should fail when every GLM account is cooling")
+	}
+	if calls != 0 {
+		t.Fatalf("upstream calls = %d, want 0", calls)
+	}
+}
+
+func TestPickAccountForModelStrictPreservesStrategy(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+	})
+
+	first := &Account{AccountID: "first", Status: "active"}
+	second := &Account{AccountID: "second", Status: "active"}
+	pool = &AccountPool{Accounts: []*Account{first, second}}
+
+	for _, strategy := range []string{"fill", "round_robin", "random"} {
+		t.Run(strategy, func(t *testing.T) {
+			pool.CurrentIdx = 0
+			cfg := defaultProxyConfig()
+			cfg.Strategy = strategy
+			setProxyConfig(cfg)
+
+			firstPick := pickAccountForModelStrict(freeModelPrimary)
+			if firstPick != first && firstPick != second {
+				t.Fatalf("first pick = %v, want an active account", firstPick)
+			}
+			if strategy == "fill" && firstPick != first {
+				t.Fatalf("fill first pick = %v, want first account", firstPick)
+			}
+			if strategy == "round_robin" {
+				secondPick := pickAccountForModelStrict(freeModelPrimary)
+				if firstPick != first || secondPick != second {
+					t.Fatalf("round_robin picks = %v, %v, want first, second", firstPick, secondPick)
+				}
+			}
+		})
+	}
+}
+
+func TestCallClineAPIDirectModelsKeepExactIDWithoutFallback(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+	})
+
+	for _, model := range []string{"z-ai/glm-5.3-flash", "deepseek/deepseek-v4-flash"} {
+		t.Run(model, func(t *testing.T) {
+			account := &Account{
+				AccountID:   "direct-account",
+				Email:       "direct@example.com",
+				AccessToken: "direct-token",
+				ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+				Status:      "active",
+			}
+			pool = &AccountPool{Accounts: []*Account{account}}
+			setProxyConfig(defaultProxyConfig())
+
+			calls := 0
+			var upstreamModel string
+			httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+				calls++
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				var params map[string]any
+				if err := json.Unmarshal(body, &params); err != nil {
+					return nil, err
+				}
+				upstreamModel, _ = params["model"].(string)
+				return &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Body:       io.NopCloser(strings.NewReader(`{"error":"quota"}`)),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			})
+
+			params := map[string]any{"model": model}
+			_, _, err := callClineAPI(params, false)
+			if err == nil {
+				t.Fatal("direct model request should return upstream quota error")
+			}
+			if calls != 1 {
+				t.Fatalf("upstream calls = %d, want 1", calls)
+			}
+			if upstreamModel != model {
+				t.Fatalf("upstream model = %q, want %q", upstreamModel, model)
+			}
+			if params["model"] != model {
+				t.Fatalf("request model changed to %v", params["model"])
+			}
+		})
+	}
+}
+
+func TestHandleResponsesFreeLogsEffectiveModel(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	requestLogsMu.Lock()
+	oldLogs := requestLogs
+	requestLogs = nil
+	requestLogsMu.Unlock()
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+		requestLogsMu.Lock()
+		requestLogs = oldLogs
+		requestLogsMu.Unlock()
+	})
+
+	account := &Account{
+		AccountID:   "log-account",
+		Email:       "log@example.com",
+		AccessToken: "log-token",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	pool = &AccountPool{Accounts: []*Account{account}}
+	setProxyConfig(defaultProxyConfig())
+
+	var upstreamModel string
+	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		var params map[string]any
+		if err := json.Unmarshal(body, &params); err != nil {
+			return nil, err
+		}
+		upstreamModel, _ = params["model"].(string)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id":"ok","model":"z-ai/glm-5.3-flash","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"free","input":"hello"}`))
+	recorder := httptest.NewRecorder()
+	handleResponses(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("response status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if upstreamModel != freeModelPrimary {
+		t.Fatalf("upstream model = %q, want %q", upstreamModel, freeModelPrimary)
+	}
+
+	requestLogsMu.Lock()
+	defer requestLogsMu.Unlock()
+	if len(requestLogs) != 1 {
+		t.Fatalf("request log count = %d, want 1", len(requestLogs))
+	}
+	if requestLogs[0].Model != freeModelPrimary {
+		t.Fatalf("request log model = %q, want %q", requestLogs[0].Model, freeModelPrimary)
+	}
+}
+
+func TestHandleResponsesFreeReturnsTooManyRequestsWhenBothPoolsUnavailable(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+	})
+
+	account := &Account{
+		AccountID:   "quota-account",
+		Email:       "quota@example.com",
+		AccessToken: "quota-token",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	pool = &AccountPool{Accounts: []*Account{account}}
+	setProxyConfig(defaultProxyConfig())
+
+	calls := 0
+	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"quota","message":"Try again in 1h"}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"free","input":"hello"}`))
+	recorder := httptest.NewRecorder()
+	handleResponses(recorder, req)
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("response status = %d, want %d: %s", recorder.Code, http.StatusTooManyRequests, recorder.Body.String())
+	}
+	if calls != 2 {
+		t.Fatalf("upstream calls = %d, want one attempt per model", calls)
+	}
+}
+
+func TestHandleResponsesFreeErrorLogsEffectiveModel(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	requestLogsMu.Lock()
+	oldLogs := requestLogs
+	requestLogs = nil
+	requestLogsMu.Unlock()
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+		requestLogsMu.Lock()
+		requestLogs = oldLogs
+		requestLogsMu.Unlock()
+	})
+
+	account := &Account{
+		AccountID:   "error-log-account",
+		Email:       "error-log@example.com",
+		AccessToken: "error-log-token",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	pool = &AccountPool{Accounts: []*Account{account}}
+	setProxyConfig(defaultProxyConfig())
+
+	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"quota","message":"Try again in 1h"}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"free","input":"hello"}`))
+	recorder := httptest.NewRecorder()
+	handleResponses(recorder, req)
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("response status = %d, want %d: %s", recorder.Code, http.StatusTooManyRequests, recorder.Body.String())
+	}
+
+	requestLogsMu.Lock()
+	defer requestLogsMu.Unlock()
+	if len(requestLogs) != 1 {
+		t.Fatalf("request log count = %d, want 1", len(requestLogs))
+	}
+	if requestLogs[0].Model != freeModelFallback {
+		t.Fatalf("request log model = %q, want %q", requestLogs[0].Model, freeModelFallback)
+	}
+}

--- a/pool.go
+++ b/pool.go
@@ -158,6 +158,14 @@ func pickAccount() *Account {
 // 所有 active 账号对该模型都冷却时回退到普通 pickAccount（请求会得到模型级 429 提示）。
 // 空模型名等同于 pickAccount。
 func pickAccountForModel(model string) *Account {
+	return pickAccountForModelWithFallback(model, true)
+}
+
+func pickAccountForModelStrict(model string) *Account {
+	return pickAccountForModelWithFallback(model, false)
+}
+
+func pickAccountForModelWithFallback(model string, fallbackToActive bool) *Account {
 	if model == "" {
 		return pickAccount()
 	}
@@ -189,8 +197,10 @@ func pickAccountForModel(model string) *Account {
 	}
 
 	if len(eligible) == 0 {
-		// 全部冷却 → 回退普通轮询，请求会带出模型级错误
-		return pickAccountLocked(p)
+		if fallbackToActive {
+			return pickAccountLocked(p)
+		}
+		return nil
 	}
 
 	cfg := getProxyConfig()

--- a/protocol_free_model_test.go
+++ b/protocol_free_model_test.go
@@ -1,0 +1,695 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+var protocolModelSyncOnce sync.Once
+
+func protocolTestServer(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve protocol test port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+
+	protocolModelSyncOnce.Do(func() {
+		modelSyncMu.Lock()
+		modelSyncRan = true
+		modelSyncMu.Unlock()
+	})
+
+	zenConfigMu.Lock()
+	oldZenConfig := zenConfig
+	zenConfig = &zenConfigData{BaseURL: zenAPIBase, Key: "public"}
+	zenConfigMu.Unlock()
+
+	oldServerMux := serverMux
+	serverMu.Lock()
+	oldServer := currentServer
+	serverMu.Unlock()
+	t.Cleanup(func() {
+		serverMu.Lock()
+		server := currentServer
+		currentServer = oldServer
+		serverMu.Unlock()
+		if server != nil && server != oldServer {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			_ = server.Shutdown(ctx)
+			cancel()
+		}
+		serverMux = oldServerMux
+		zenConfigMu.Lock()
+		zenConfig = oldZenConfig
+		zenConfigMu.Unlock()
+	})
+
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- startProxy("127.0.0.1", port)
+	}()
+
+	baseURL := "http://127.0.0.1:" + strconv.Itoa(port)
+	client := &http.Client{Timeout: 2 * time.Second}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		resp, requestErr := client.Get(baseURL + "/health")
+		if requestErr == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				break
+			}
+		}
+		select {
+		case startErr := <-serverErr:
+			t.Fatalf("start protocol test server: %v", startErr)
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for protocol test server")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	return baseURL
+}
+
+func TestOpenAIChatCompletionsFreeFallsBackToDS(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+	})
+
+	first := &Account{
+		AccountID:   "chat-glm",
+		Email:       "chat-glm@example.com",
+		AccessToken: "chat-glm-token",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	second := &Account{
+		AccountID:   "chat-ds",
+		Email:       "chat-ds@example.com",
+		AccessToken: "chat-ds-token",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	pool = &AccountPool{Accounts: []*Account{first, second}}
+	config := defaultProxyConfig()
+	config.Strategy = "fill"
+	setProxyConfig(config)
+
+	var attempts []string
+	var models []string
+	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+		token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
+		attempts = append(attempts, token)
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		var params map[string]any
+		if err := json.Unmarshal(body, &params); err != nil {
+			return nil, err
+		}
+		model, _ := params["model"].(string)
+		models = append(models, model)
+		if model == freeModelPrimary {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"quota","message":"Try again in 1h"}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id":"chat-ok","model":"deepseek/deepseek-v4-flash","choices":[{"message":{"role":"assistant","content":"fallback"},"finish_reason":"stop"}]}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	baseURL := protocolTestServer(t)
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions", strings.NewReader(`{"model":"free","messages":[{"role":"user","content":"hello"}]}`))
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	responseClient := &http.Client{Transport: &http.Transport{}, Timeout: 2 * time.Second}
+	resp, err := responseClient.Do(req)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("response status = %d, want %d: %s", resp.StatusCode, http.StatusOK, responseBody)
+	}
+	var response map[string]any
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	message, ok := response["choices"].([]any)
+	if !ok || len(message) != 1 {
+		t.Fatalf("response choices = %v, want one choice", response["choices"])
+	}
+	choice, _ := message[0].(map[string]any)
+	content, _ := choice["message"].(map[string]any)["content"].(string)
+	if content != "fallback" {
+		t.Fatalf("response content = %q, want fallback", content)
+	}
+	if got, want := strings.Join(attempts, ","), "chat-glm-token,chat-ds-token,chat-glm-token"; got != want {
+		t.Fatalf("attempts = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(models, ","), freeModelPrimary+","+freeModelPrimary+","+freeModelFallback; got != want {
+		t.Fatalf("models = %q, want %q", got, want)
+	}
+}
+
+func TestOpenAIChatCompletionsFreeRetriesNextGLMAccount(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+	})
+
+	first := &Account{
+		AccountID:   "chat-retry-glm-one",
+		Email:       "chat-retry-one@example.com",
+		AccessToken: "chat-retry-token-one",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	second := &Account{
+		AccountID:   "chat-retry-glm-two",
+		Email:       "chat-retry-two@example.com",
+		AccessToken: "chat-retry-token-two",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	pool = &AccountPool{Accounts: []*Account{first, second}}
+	config := defaultProxyConfig()
+	config.Strategy = "fill"
+	setProxyConfig(config)
+
+	var attempts []string
+	var models []string
+	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+		token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
+		attempts = append(attempts, token)
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		var params map[string]any
+		if err := json.Unmarshal(body, &params); err != nil {
+			return nil, err
+		}
+		model, _ := params["model"].(string)
+		models = append(models, model)
+		if token == first.AccessToken {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"quota","message":"Try again in 1h"}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id":"chat-glm-ok","model":"z-ai/glm-5.3-flash","choices":[{"message":{"role":"assistant","content":"glm retry"},"finish_reason":"stop"}]}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	baseURL := protocolTestServer(t)
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions", strings.NewReader(`{"model":"free","messages":[{"role":"user","content":"hello"}]}`))
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	responseClient := &http.Client{Transport: &http.Transport{}, Timeout: 2 * time.Second}
+	resp, err := responseClient.Do(req)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("response status = %d, want %d: %s", resp.StatusCode, http.StatusOK, responseBody)
+	}
+	var response map[string]any
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	choices, ok := response["choices"].([]any)
+	if !ok || len(choices) != 1 {
+		t.Fatalf("response choices = %v, want one choice", response["choices"])
+	}
+	choice, _ := choices[0].(map[string]any)
+	content, _ := choice["message"].(map[string]any)["content"].(string)
+	if content != "glm retry" {
+		t.Fatalf("response content = %q, want glm retry", content)
+	}
+	if got, want := strings.Join(attempts, ","), first.AccessToken+","+second.AccessToken; got != want {
+		t.Fatalf("attempts = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(models, ","), freeModelPrimary+","+freeModelPrimary; got != want {
+		t.Fatalf("models = %q, want %q", got, want)
+	}
+}
+
+func TestOpenAIResponsesFreeFallsBackToDSAndPreservesResponseFormat(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+	})
+
+	first := &Account{
+		AccountID:   "responses-glm",
+		Email:       "responses-glm@example.com",
+		AccessToken: "responses-glm-token",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	second := &Account{
+		AccountID:   "responses-ds",
+		Email:       "responses-ds@example.com",
+		AccessToken: "responses-ds-token",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	pool = &AccountPool{Accounts: []*Account{first, second}}
+	config := defaultProxyConfig()
+	config.Strategy = "fill"
+	setProxyConfig(config)
+
+	var attempts []string
+	var models []string
+	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+		token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
+		attempts = append(attempts, token)
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		var params map[string]any
+		if err := json.Unmarshal(body, &params); err != nil {
+			return nil, err
+		}
+		model, _ := params["model"].(string)
+		models = append(models, model)
+		if model == freeModelPrimary {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"quota","message":"Try again in 1h"}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id":"responses-ok","model":"deepseek/deepseek-v4-flash","choices":[{"message":{"role":"assistant","content":"responses fallback"},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	baseURL := protocolTestServer(t)
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/responses", strings.NewReader(`{"model":"free","input":"hello"}`))
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	responseClient := &http.Client{Transport: &http.Transport{}, Timeout: 2 * time.Second}
+	resp, err := responseClient.Do(req)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("response status = %d, want %d: %s", resp.StatusCode, http.StatusOK, responseBody)
+	}
+	var response map[string]any
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response["object"] != "response" || response["status"] != "completed" {
+		t.Fatalf("response envelope = %v, want completed Responses response", response)
+	}
+	if response["model"] != freeModelFallback {
+		t.Fatalf("response model = %v, want %q", response["model"], freeModelFallback)
+	}
+	if response["output_text"] != "responses fallback" {
+		t.Fatalf("output_text = %v, want responses fallback", response["output_text"])
+	}
+	if _, ok := response["choices"]; ok {
+		t.Fatalf("Responses response unexpectedly contains choices: %v", response)
+	}
+	if got, want := strings.Join(attempts, ","), "responses-glm-token,responses-ds-token,responses-glm-token"; got != want {
+		t.Fatalf("attempts = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(models, ","), freeModelPrimary+","+freeModelPrimary+","+freeModelFallback; got != want {
+		t.Fatalf("models = %q, want %q", got, want)
+	}
+}
+
+func TestAnthropicMessagesFreeFallsBackToDSAndPreservesResponseFormat(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+	})
+
+	first := &Account{
+		AccountID:   "anthropic-glm",
+		Email:       "anthropic-glm@example.com",
+		AccessToken: "anthropic-glm-token",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	second := &Account{
+		AccountID:   "anthropic-ds",
+		Email:       "anthropic-ds@example.com",
+		AccessToken: "anthropic-ds-token",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	pool = &AccountPool{Accounts: []*Account{first, second}}
+	config := defaultProxyConfig()
+	config.Strategy = "fill"
+	setProxyConfig(config)
+
+	var attempts []string
+	var models []string
+	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+		token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
+		attempts = append(attempts, token)
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		var params map[string]any
+		if err := json.Unmarshal(body, &params); err != nil {
+			return nil, err
+		}
+		model, _ := params["model"].(string)
+		models = append(models, model)
+		if model == freeModelPrimary {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"quota","message":"Try again in 1h"}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id":"anthropic-ok","model":"deepseek/deepseek-v4-flash","choices":[{"message":{"role":"assistant","content":"anthropic fallback"},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	baseURL := protocolTestServer(t)
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/messages", strings.NewReader(`{"model":"free","max_tokens":32,"messages":[{"role":"user","content":"hello"}]}`))
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	responseClient := &http.Client{Transport: &http.Transport{}, Timeout: 2 * time.Second}
+	resp, err := responseClient.Do(req)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("response status = %d, want %d: %s", resp.StatusCode, http.StatusOK, responseBody)
+	}
+	var response map[string]any
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response["type"] != "message" || response["role"] != "assistant" {
+		t.Fatalf("response envelope = %v, want Anthropic message", response)
+	}
+	if response["model"] != freeModelFallback {
+		t.Fatalf("response model = %v, want %q", response["model"], freeModelFallback)
+	}
+	content, ok := response["content"].([]any)
+	if !ok || len(content) != 1 {
+		t.Fatalf("response content = %v, want one block", response["content"])
+	}
+	block, _ := content[0].(map[string]any)
+	if block["type"] != "text" || block["text"] != "anthropic fallback" {
+		t.Fatalf("response content block = %v", block)
+	}
+	if response["stop_reason"] != "end_turn" {
+		t.Fatalf("stop_reason = %v, want end_turn", response["stop_reason"])
+	}
+	usage, _ := response["usage"].(map[string]any)
+	if usage["input_tokens"] != float64(4) || usage["output_tokens"] != float64(2) {
+		t.Fatalf("usage = %v, want input=4 output=2", usage)
+	}
+	if got, want := strings.Join(attempts, ","), "anthropic-glm-token,anthropic-ds-token,anthropic-glm-token"; got != want {
+		t.Fatalf("attempts = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(models, ","), freeModelPrimary+","+freeModelPrimary+","+freeModelFallback; got != want {
+		t.Fatalf("models = %q, want %q", got, want)
+	}
+}
+
+func TestOpenAIChatCompletionsFreeStreamFallsBackBeforeResponseHeaders(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+	})
+
+	first := &Account{
+		AccountID:   "chat-stream-glm",
+		Email:       "chat-stream-glm@example.com",
+		AccessToken: "chat-stream-glm-token",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	second := &Account{
+		AccountID:   "chat-stream-ds",
+		Email:       "chat-stream-ds@example.com",
+		AccessToken: "chat-stream-ds-token",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	pool = &AccountPool{Accounts: []*Account{first, second}}
+	config := defaultProxyConfig()
+	config.Strategy = "fill"
+	setProxyConfig(config)
+
+	var attempts []string
+	var models []string
+	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+		token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
+		attempts = append(attempts, token)
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		var params map[string]any
+		if err := json.Unmarshal(body, &params); err != nil {
+			return nil, err
+		}
+		model, _ := params["model"].(string)
+		models = append(models, model)
+		if model == freeModelPrimary {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"quota","message":"Try again in 1h"}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("data: {\"id\":\"stream-ok\",\"model\":\"deepseek/deepseek-v4-flash\",\"choices\":[{\"delta\":{\"content\":\"stream fallback\"}}]}\n\ndata: [DONE]\n\n")),
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Request:    req,
+		}, nil
+	})
+
+	baseURL := protocolTestServer(t)
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions", strings.NewReader(`{"model":"free","stream":true,"messages":[{"role":"user","content":"hello"}]}`))
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	responseClient := &http.Client{Transport: &http.Transport{}, Timeout: 2 * time.Second}
+	resp, err := responseClient.Do(req)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("response status = %d, want %d: %s", resp.StatusCode, http.StatusOK, responseBody)
+	}
+	if !strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream") {
+		t.Fatalf("content type = %q, want text/event-stream", resp.Header.Get("Content-Type"))
+	}
+	if !strings.Contains(string(responseBody), "stream fallback") {
+		t.Fatalf("response body = %q, want fallback event", responseBody)
+	}
+	if got, want := strings.Join(attempts, ","), "chat-stream-glm-token,chat-stream-ds-token,chat-stream-glm-token"; got != want {
+		t.Fatalf("attempts = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(models, ","), freeModelPrimary+","+freeModelPrimary+","+freeModelFallback; got != want {
+		t.Fatalf("models = %q, want %q", got, want)
+	}
+}
+
+func TestDeepseekFreeZenAliasesStayOnZen(t *testing.T) {
+	withZenPool(t, append([]Model{}, builtinZenModels()...))
+	for _, model := range []string{
+		"deepseek-v4-flash-free",
+		"opencode/deepseek-v4-flash-free",
+		"deepseek-v4-flash",
+		"deepseek-v4",
+	} {
+		if got := routeModel(model); got != "zen" {
+			t.Errorf("routeModel(%q) = %q, want zen", model, got)
+		}
+	}
+}
+
+func TestOpenAIChatCompletionsFreeStreamDoesNotRetryAfterResponseStarts(t *testing.T) {
+	oldPool := pool
+	oldConfig := getProxyConfig()
+	oldTransport := httpClient.Transport
+	t.Cleanup(func() {
+		pool = oldPool
+		setProxyConfig(oldConfig)
+		httpClient.Transport = oldTransport
+	})
+
+	first := &Account{
+		AccountID:   "chat-started-glm",
+		Email:       "chat-started-glm@example.com",
+		AccessToken: "chat-started-glm-token",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	second := &Account{
+		AccountID:   "chat-started-second",
+		Email:       "chat-started-second@example.com",
+		AccessToken: "chat-started-second-token",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Status:      "active",
+	}
+	pool = &AccountPool{Accounts: []*Account{first, second}}
+	config := defaultProxyConfig()
+	config.Strategy = "fill"
+	setProxyConfig(config)
+
+	var attempts []string
+	var models []string
+	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
+		token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
+		attempts = append(attempts, token)
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		var params map[string]any
+		if err := json.Unmarshal(body, &params); err != nil {
+			return nil, err
+		}
+		model, _ := params["model"].(string)
+		models = append(models, model)
+		if len(attempts) > 1 {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"unexpected retry"}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("data: {\"id\":\"stream-started\",\"model\":\"z-ai/glm-5.3-flash\",\"choices\":[{\"delta\":{\"content\":\"stream started\"}}]}\n\ndata: [DONE]\n\n")),
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Request:    req,
+		}, nil
+	})
+
+	baseURL := protocolTestServer(t)
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions", strings.NewReader(`{"model":"free","stream":true,"messages":[{"role":"user","content":"hello"}]}`))
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	responseClient := &http.Client{Transport: &http.Transport{}, Timeout: 2 * time.Second}
+	resp, err := responseClient.Do(req)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("response status = %d, want %d: %s", resp.StatusCode, http.StatusOK, responseBody)
+	}
+	if !strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream") {
+		t.Fatalf("content type = %q, want text/event-stream", resp.Header.Get("Content-Type"))
+	}
+	if !strings.Contains(string(responseBody), "stream started") {
+		t.Fatalf("response body = %q, want first stream event", responseBody)
+	}
+	if got, want := strings.Join(attempts, ","), first.AccessToken; got != want {
+		t.Fatalf("attempts = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(models, ","), freeModelPrimary; got != want {
+		t.Fatalf("models = %q, want %q", got, want)
+	}
+}

--- a/protocol_free_model_test.go
+++ b/protocol_free_model_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -184,113 +185,28 @@ func TestOpenAIChatCompletionsFreeFallsBackToDS(t *testing.T) {
 	}
 }
 
-func TestOpenAIChatCompletionsFreeRetriesNextGLMAccount(t *testing.T) {
-	oldPool := pool
-	oldConfig := getProxyConfig()
-	oldTransport := httpClient.Transport
-	t.Cleanup(func() {
-		pool = oldPool
-		setProxyConfig(oldConfig)
-		httpClient.Transport = oldTransport
-	})
-
-	first := &Account{
-		AccountID:   "chat-retry-glm-one",
-		Email:       "chat-retry-one@example.com",
-		AccessToken: "chat-retry-token-one",
-		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
-		Status:      "active",
-	}
-	second := &Account{
-		AccountID:   "chat-retry-glm-two",
-		Email:       "chat-retry-two@example.com",
-		AccessToken: "chat-retry-token-two",
-		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
-		Status:      "active",
-	}
-	pool = &AccountPool{Accounts: []*Account{first, second}}
-	config := defaultProxyConfig()
-	config.Strategy = "fill"
-	setProxyConfig(config)
-
-	var attempts []string
-	var models []string
-	httpClient.Transport = freeModelRoundTripper(func(req *http.Request) (*http.Response, error) {
-		token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
-		attempts = append(attempts, token)
-		body, err := io.ReadAll(req.Body)
-		if err != nil {
-			return nil, err
-		}
-		var params map[string]any
-		if err := json.Unmarshal(body, &params); err != nil {
-			return nil, err
-		}
-		model, _ := params["model"].(string)
-		models = append(models, model)
-		if token == first.AccessToken {
-			return &http.Response{
-				StatusCode: http.StatusTooManyRequests,
-				Body:       io.NopCloser(strings.NewReader(`{"error":"quota","message":"Try again in 1h"}`)),
-				Header:     make(http.Header),
-				Request:    req,
-			}, nil
-		}
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"id":"chat-glm-ok","model":"z-ai/glm-5.3-flash","choices":[{"message":{"role":"assistant","content":"glm retry"},"finish_reason":"stop"}]}`)),
-			Header:     make(http.Header),
-			Request:    req,
-		}, nil
-	})
-
-	baseURL := protocolTestServer(t)
-	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions", strings.NewReader(`{"model":"free","messages":[{"role":"user","content":"hello"}]}`))
-	if err != nil {
-		t.Fatalf("create request: %v", err)
-	}
-	responseClient := &http.Client{Transport: &http.Transport{}, Timeout: 2 * time.Second}
-	resp, err := responseClient.Do(req)
-	if err != nil {
-		t.Fatalf("send request: %v", err)
-	}
-	defer resp.Body.Close()
-	responseBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("read response: %v", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("response status = %d, want %d: %s", resp.StatusCode, http.StatusOK, responseBody)
-	}
-	var response map[string]any
-	if err := json.Unmarshal(responseBody, &response); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	choices, ok := response["choices"].([]any)
-	if !ok || len(choices) != 1 {
-		t.Fatalf("response choices = %v, want one choice", response["choices"])
-	}
-	choice, _ := choices[0].(map[string]any)
-	content, _ := choice["message"].(map[string]any)["content"].(string)
-	if content != "glm retry" {
-		t.Fatalf("response content = %q, want glm retry", content)
-	}
-	if got, want := strings.Join(attempts, ","), first.AccessToken+","+second.AccessToken; got != want {
-		t.Fatalf("attempts = %q, want %q", got, want)
-	}
-	if got, want := strings.Join(models, ","), freeModelPrimary+","+freeModelPrimary; got != want {
-		t.Fatalf("models = %q, want %q", got, want)
-	}
-}
-
 func TestOpenAIResponsesFreeFallsBackToDSAndPreservesResponseFormat(t *testing.T) {
 	oldPool := pool
 	oldConfig := getProxyConfig()
 	oldTransport := httpClient.Transport
+	oldLogData, oldLogErr := os.ReadFile(requestLogsPath)
+	requestLogsMu.Lock()
+	oldLogs := requestLogs
+	requestLogs = nil
+	requestLogsMu.Unlock()
+	_ = os.Remove(requestLogsPath)
 	t.Cleanup(func() {
 		pool = oldPool
 		setProxyConfig(oldConfig)
 		httpClient.Transport = oldTransport
+		requestLogsMu.Lock()
+		requestLogs = oldLogs
+		requestLogsMu.Unlock()
+		if oldLogErr != nil {
+			_ = os.Remove(requestLogsPath)
+		} else {
+			_ = os.WriteFile(requestLogsPath, oldLogData, 0600)
+		}
 	})
 
 	first := &Account{
@@ -382,6 +298,15 @@ func TestOpenAIResponsesFreeFallsBackToDSAndPreservesResponseFormat(t *testing.T
 	}
 	if got, want := strings.Join(models, ","), freeModelPrimary+","+freeModelPrimary+","+freeModelFallback; got != want {
 		t.Fatalf("models = %q, want %q", got, want)
+	}
+
+	requestLogsMu.Lock()
+	defer requestLogsMu.Unlock()
+	if len(requestLogs) != 1 {
+		t.Fatalf("request log count = %d, want 1", len(requestLogs))
+	}
+	if requestLogs[0].Model != freeModelFallback {
+		t.Fatalf("request log model = %q, want %q", requestLogs[0].Model, freeModelFallback)
 	}
 }
 
@@ -585,20 +510,6 @@ func TestOpenAIChatCompletionsFreeStreamFallsBackBeforeResponseHeaders(t *testin
 	}
 	if got, want := strings.Join(models, ","), freeModelPrimary+","+freeModelPrimary+","+freeModelFallback; got != want {
 		t.Fatalf("models = %q, want %q", got, want)
-	}
-}
-
-func TestDeepseekFreeZenAliasesStayOnZen(t *testing.T) {
-	withZenPool(t, append([]Model{}, builtinZenModels()...))
-	for _, model := range []string{
-		"deepseek-v4-flash-free",
-		"opencode/deepseek-v4-flash-free",
-		"deepseek-v4-flash",
-		"deepseek-v4",
-	} {
-		if got := routeModel(model); got != "zen" {
-			t.Errorf("routeModel(%q) = %q, want zen", model, got)
-		}
 	}
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -22,6 +23,8 @@ const (
 	defaultMaxTokens       = 128000
 	defaultReasoningEffort = "high"
 	fallbackDefaultModel   = "cline-free/glm-5.2"
+	freeModelPrimary       = "z-ai/glm-5.3-flash"
+	freeModelFallback      = "deepseek/deepseek-v4-flash"
 )
 
 // builtinModels 是内置默认模型列表（不可删除），仅作为离线 / 未同步时的 fallback。
@@ -308,9 +311,9 @@ func startProxy(host string, port int) error {
 				ownedBy = "opencode"
 			}
 			list[i] = map[string]any{
-				"id":      m.ID,
-				"object":  "model",
-				"created": time.Now().UnixMilli(),
+				"id":       m.ID,
+				"object":   "model",
+				"created":  time.Now().UnixMilli(),
 				"owned_by": ownedBy,
 			}
 		}
@@ -426,10 +429,13 @@ func startProxy(host string, port int) error {
 		}
 
 		resp, acc, err := callClineAPI(params, isStream)
+		if effectiveModel, ok := params["model"].(string); ok && effectiveModel != "" {
+			reqLog.Model = effectiveModel
+		}
 		if err != nil {
 			log.Printf("  api error: %v", err)
 			finalizeRequestLog(&reqLog, tokenUsage{}, time.Time{}, reqLog.StartedAt, false, err.Error())
-			writeJSON(w, http.StatusInternalServerError, map[string]any{
+			writeJSON(w, clineErrorHTTPStatus(err), map[string]any{
 				"error": map[string]string{"message": err.Error(), "type": "api_error"},
 			})
 			return
@@ -612,8 +618,48 @@ func clineHeaders(token, sessionID string) http.Header {
 	return h
 }
 
+type clineAPIError struct {
+	statusCode int
+	message    string
+}
+
+func (e *clineAPIError) Error() string {
+	return fmt.Sprintf("API %d: %s", e.statusCode, e.message)
+}
+
+type clineAccountUnavailableError struct {
+	err error
+}
+
+func (e *clineAccountUnavailableError) Error() string {
+	return e.err.Error()
+}
+
+func (e *clineAccountUnavailableError) Unwrap() error {
+	return e.err
+}
+
+type freeModelUnavailableError struct {
+	message string
+}
+
+func (e *freeModelUnavailableError) Error() string {
+	return e.message
+}
+
+func clineErrorHTTPStatus(err error) int {
+	if _, ok := err.(*freeModelUnavailableError); ok {
+		return http.StatusTooManyRequests
+	}
+	return http.StatusInternalServerError
+}
+
 func callClineAPI(params map[string]any, stream bool) (*http.Response, *Account, error) {
 	model, _ := params["model"].(string)
+	if model == "free" {
+		return callFreeClineAPI(params, stream)
+	}
+
 	acc := pickAccountForModel(model)
 	if acc == nil {
 		return nil, nil, fmt.Errorf("no active accounts available. Use --login or admin API to add accounts")
@@ -621,11 +667,37 @@ func callClineAPI(params map[string]any, stream bool) (*http.Response, *Account,
 	return callClineAPIWithAccount(acc, params, stream)
 }
 
+func callFreeClineAPI(params map[string]any, stream bool) (*http.Response, *Account, error) {
+	for _, model := range []string{freeModelPrimary, freeModelFallback} {
+		params["model"] = model
+		for {
+			acc := pickAccountForModelStrict(model)
+			if acc == nil {
+				break
+			}
+
+			resp, usedAcc, err := callClineAPIWithAccount(acc, params, stream)
+			if err == nil {
+				return resp, usedAcc, nil
+			}
+			var accountErr *clineAccountUnavailableError
+			if errors.As(err, &accountErr) {
+				continue
+			}
+			apiErr, ok := err.(*clineAPIError)
+			if !ok || apiErr.statusCode != http.StatusTooManyRequests {
+				return nil, usedAcc, err
+			}
+		}
+	}
+	return nil, nil, &freeModelUnavailableError{message: "no eligible accounts available for free models"}
+}
+
 func callClineAPIWithAccount(acc *Account, params map[string]any, stream bool) (*http.Response, *Account, error) {
 	token, err := ensureAccountToken(acc)
 	if err != nil {
 		// Try other accounts
-		return nil, acc, fmt.Errorf("account %s token failed: %w", acc.Email, err)
+		return nil, acc, &clineAccountUnavailableError{err: fmt.Errorf("account %s token failed: %w", acc.Email, err)}
 	}
 
 	body := buildUpstreamBody(params, stream)
@@ -656,7 +728,7 @@ func callClineAPIWithAccount(acc *Account, params map[string]any, stream bool) (
 		acc.Status = "cooldown"
 		acc.CooldownUntil = time.Now().Add(5 * time.Minute)
 		savePool()
-		return nil, acc, fmt.Errorf("upstream request: %w", err)
+		return nil, acc, &clineAccountUnavailableError{err: fmt.Errorf("upstream request: %w", err)}
 	}
 
 	if resp.StatusCode == 401 {
@@ -665,20 +737,24 @@ func callClineAPIWithAccount(acc *Account, params map[string]any, stream bool) (
 		if err := refreshAccountToken(acc); err == nil {
 			token = acc.AccessToken
 			req.Header = clineHeaders(token, sessionID)
+			req.Body = io.NopCloser(bytes.NewReader(bodyJSON))
 			resp, err = httpClient.Do(req)
 			if err != nil {
-				return nil, acc, fmt.Errorf("upstream retry: %w", err)
+				acc.Status = "cooldown"
+				acc.CooldownUntil = time.Now().Add(5 * time.Minute)
+				savePool()
+				return nil, acc, &clineAccountUnavailableError{err: fmt.Errorf("upstream retry: %w", err)}
 			}
 			if resp.StatusCode == 401 {
 				resp.Body.Close()
 				acc.Status = "expired"
 				savePool()
-				return nil, acc, fmt.Errorf("account %s token expired permanently", acc.Email)
+				return nil, acc, &clineAccountUnavailableError{err: fmt.Errorf("account %s token expired permanently", acc.Email)}
 			}
 		} else {
 			acc.Status = "expired"
 			savePool()
-			return nil, acc, fmt.Errorf("account %s refresh failed: %w", acc.Email, err)
+			return nil, acc, &clineAccountUnavailableError{err: fmt.Errorf("account %s refresh failed: %w", acc.Email, err)}
 		}
 	}
 
@@ -698,7 +774,7 @@ func callClineAPIWithAccount(acc *Account, params map[string]any, stream bool) (
 				savePool()
 			}
 		}
-		return nil, acc, fmt.Errorf("API %d: %s", resp.StatusCode, truncate(bodyStr, 500))
+		return nil, acc, &clineAPIError{statusCode: resp.StatusCode, message: truncate(bodyStr, 500)}
 	}
 
 	acc.LastUsed = time.Now()
@@ -1559,10 +1635,13 @@ func handleAnthropicMessages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp, acc, err := callClineAPI(openAIReq, req.Stream)
+	if effectiveModel, ok := openAIReq["model"].(string); ok && effectiveModel != "" {
+		reqLog.Model = effectiveModel
+	}
 	if err != nil {
 		log.Printf("  anthropic api error: %v", err)
 		finalizeRequestLog(&reqLog, tokenUsage{}, time.Time{}, reqLog.StartedAt, false, err.Error())
-		writeJSON(w, http.StatusInternalServerError, map[string]any{
+		writeJSON(w, clineErrorHTTPStatus(err), map[string]any{
 			"error": map[string]string{"message": err.Error(), "type": "api_error"},
 		})
 		return

--- a/proxy.go
+++ b/proxy.go
@@ -22,15 +22,22 @@ import (
 const (
 	defaultMaxTokens       = 128000
 	defaultReasoningEffort = "high"
-	fallbackDefaultModel   = "cline-free/glm-5.2"
+	fallbackDefaultModel   = "z-ai/glm-5.3-flash"
 	freeModelPrimary       = "z-ai/glm-5.3-flash"
 	freeModelFallback      = "deepseek/deepseek-v4-flash"
+	freeModelLastResort    = "cline-free/longcat-2.0"
 )
+
+// freeModelChain 是 model="free" 时的降级顺序。
+// 顺序依据 Artificial Analysis Intelligence Index v4.1.1：
+// glm-5.3-flash 57 > deepseek-v4-flash 0731 52 > longcat-2.0 34。
+var freeModelChain = []string{freeModelPrimary, freeModelFallback, freeModelLastResort}
 
 // builtinModels 是内置默认模型列表（不可删除），仅作为离线 / 未同步时的 fallback。
 // 同步 Cline 官方推荐模型成功后，getAllModels 以远程模型为主。
 var builtinModels = []Model{
-	{ID: "cline-free/glm-5.2", Provider: "zai", Cost: "free", Status: "active", Custom: false},
+	{ID: "z-ai/glm-5.3-flash", Provider: "z-ai", Cost: "free", Status: "active", Custom: false},
+	{ID: "cline-free/longcat-2.0", Provider: "cline-free", Cost: "free", Status: "active", Custom: false},
 	{ID: "cline-pass/glm-5.2", Provider: "zai", Cost: "pass", Status: "active", Custom: false},
 	{ID: "cline-pass/deepseek-v4-flash", Provider: "deepseek", Cost: "pass", Status: "active", Custom: false},
 	{ID: "cline-pass/qwen3.7-max", Provider: "qwen", Cost: "pass", Status: "active", Custom: false},
@@ -668,7 +675,7 @@ func callClineAPI(params map[string]any, stream bool) (*http.Response, *Account,
 }
 
 func callFreeClineAPI(params map[string]any, stream bool) (*http.Response, *Account, error) {
-	for _, model := range []string{freeModelPrimary, freeModelFallback} {
+	for _, model := range freeModelChain {
 		params["model"] = model
 		for {
 			acc := pickAccountForModelStrict(model)

--- a/responses.go
+++ b/responses.go
@@ -85,8 +85,8 @@ func responsesInputToMessages(input any) []any {
 					"role":    "assistant",
 					"content": "",
 					"tool_calls": []any{map[string]any{
-						"id":   callID,
-						"type": "function",
+						"id":       callID,
+						"type":     "function",
 						"function": map[string]any{"name": name, "arguments": args},
 					}},
 				})
@@ -532,10 +532,13 @@ func handleResponses(w http.ResponseWriter, r *http.Request) {
 	default: // cline
 		reqLog.Upstream = upstreamCline
 		upResp, acc, err := callClineAPI(chat, isStream)
+		if effectiveModel, ok := chat["model"].(string); ok && effectiveModel != "" {
+			reqLog.Model = effectiveModel
+		}
 		if err != nil {
 			log.Printf("  responses api error: %v", err)
 			finalizeRequestLog(&reqLog, tokenUsage{}, time.Time{}, reqLog.StartedAt, false, err.Error())
-			writeJSON(w, http.StatusInternalServerError, map[string]any{
+			writeJSON(w, clineErrorHTTPStatus(err), map[string]any{
 				"error": map[string]string{"message": err.Error(), "type": "api_error"},
 			})
 			return

--- a/zen_test.go
+++ b/zen_test.go
@@ -94,10 +94,16 @@ func TestRouteModelZenFree(t *testing.T) {
 	if got := routeModel("deepseek-v4-flash-free"); got != "zen" {
 		t.Errorf("routeModel(free seed model) = %q, want zen", got)
 	}
+	if got := routeModel("opencode/deepseek-v4-flash-free"); got != "zen" {
+		t.Errorf("routeModel(prefixed free seed model) = %q, want zen", got)
+	}
 	if got := routeModel("opencode/mimo-v2.5-free"); got != "zen" {
 		t.Errorf("routeModel(opencode/ prefix) = %q, want zen", got)
 	}
 	// 别名
+	if got := routeModel("deepseek-v4-flash"); got != "zen" {
+		t.Errorf("routeModel(free model alias) = %q, want zen", got)
+	}
 	if got := routeModel("deepseek-v4"); got != "zen" {
 		t.Errorf("routeModel(alias) = %q, want zen", got)
 	}


### PR DESCRIPTION
## Summary

- add a virtual `free` model that always starts with `z-ai/glm-5.3-flash`
- retry eligible accounts within the same model before falling back to `deepseek/deepseek-v4-flash`
- return to GLM automatically on the next request after a GLM cooldown expires
- preserve direct GLM/DS model selection and existing Zen routing
- replay the original request body after a successful 401 token refresh

## Behavior

`free` now follows this order:

1. eligible GLM accounts, using the configured account strategy
2. eligible DeepSeek accounts only after the GLM pool is unavailable
3. HTTP 429 when both pools are unavailable

Account-scoped token or transport failures continue to another eligible account. Non-429 upstream provider errors still stop immediately. Failover only happens before response streaming begins.

## Scope

- no new persisted config or management UI
- no routing DSL or weighted balancing
- no CLIProxyAPI source changes

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- binary build
- isolated live smoke with a copied account pool:
  - all copied GLM entries cooling -> HTTP 200 from `deepseek/deepseek-v4-flash-0731`
  - GLM entries available -> HTTP 200 from `z-ai/glm-5.3-flash`

The test suite covers OpenAI Chat Completions, Anthropic Messages, OpenAI Responses, stream boundaries, direct models, account strategies, cooldown recovery, and Zen routing regression.